### PR TITLE
New hooks

### DIFF
--- a/Carbon.Core/Carbon/Hooks/Carbon/Resources/OnGrowableUpdate.cs
+++ b/Carbon.Core/Carbon/Hooks/Carbon/Resources/OnGrowableUpdate.cs
@@ -10,7 +10,8 @@ namespace Carbon.Extended
     [CarbonHook("OnGrowableUpdate"), CarbonHook.Category(CarbonHook.Category.Enum.Resources)]
     [CarbonHook.Parameter("this", typeof(GrowableEntity))]
     [CarbonHook.Info("Called before growable entity will be updated.")]
-    [CarbonHook.Patch(typeof(GrowableEntity), "RunUpdate")]
+	[CarbonHook.Info("No return behavior.")]
+	[CarbonHook.Patch(typeof(GrowableEntity), "RunUpdate")]
     public class GrowableEntity_RunUpdate
     {
         public static void Prefix(ref GrowableEntity __instance)

--- a/Carbon.Core/Carbon/Hooks/Carbon/Resources/OnGrowableUpdate.cs
+++ b/Carbon.Core/Carbon/Hooks/Carbon/Resources/OnGrowableUpdate.cs
@@ -1,0 +1,21 @@
+﻿///
+/// Copyright (c) 2022 Carbon Community 
+/// All rights reserved
+/// 
+
+using Carbon.Core;
+
+namespace Carbon.Extended
+{
+    [CarbonHook("OnGrowableUpdate"), CarbonHook.Category(CarbonHook.Category.Enum.Resources)]
+    [CarbonHook.Parameter("this", typeof(GrowableEntity))]
+    [CarbonHook.Info("Called before growable entity will be updated.")]
+    [CarbonHook.Patch(typeof(GrowableEntity), "RunUpdate")]
+    public class GrowableEntity_RunUpdate
+    {
+        public static void Prefix(ref GrowableEntity __instance)
+        {
+            HookExecutor.CallStaticHook("OnGrowableUpdate", __instance);
+        }
+    }
+}

--- a/Carbon.Core/Carbon/Hooks/Oxide/Entity/CanWaterBallSplash.cs
+++ b/Carbon.Core/Carbon/Hooks/Oxide/Entity/CanWaterBallSplash.cs
@@ -14,17 +14,17 @@ namespace Carbon.Extended
 	[OxideHook.Parameter("radius", typeof(float))]
 	[OxideHook.Parameter("amount", typeof(int))]
 	[OxideHook.Info("Called before water is poured from a liquid vessel or shot from a water gun")]
+	[OxideHook.Info("Returning a false value overrides default behavior")]
 	[OxideHook.Patch(typeof(WaterBall), "DoSplash", typeof(Vector3), typeof(float), typeof(ItemDefinition), typeof(int))]
 	public class WaterBall_DoSplash
 	{
-		public static bool Prefix(Vector3 position, float radius, ItemDefinition liquidDef, int amount, ref bool __result)
+		public static bool Prefix(Vector3 position, float radius, ItemDefinition liquidDef, int amount)
 		{
 			var obj = Interface.CallHook("CanWaterBallSplash", liquidDef, position, radius, amount);
 
 			if (obj is bool)
 			{
-				__result = (bool)obj;
-				return __result;
+				return (bool)obj;
 			}
 
 			return true;

--- a/Carbon.Core/Carbon/Hooks/Oxide/Entity/CanWaterBallSplash.cs
+++ b/Carbon.Core/Carbon/Hooks/Oxide/Entity/CanWaterBallSplash.cs
@@ -1,0 +1,33 @@
+﻿///
+/// Copyright (c) 2022 Carbon Community 
+/// All rights reserved
+/// 
+
+using Oxide.Core;
+using UnityEngine;
+
+namespace Carbon.Extended
+{
+	[OxideHook("CanWaterBallSplash", typeof(bool)), OxideHook.Category(Hook.Category.Enum.Entity)]
+	[OxideHook.Parameter("liquidDef", typeof(ItemDefinition))]
+	[OxideHook.Parameter("position", typeof(Vector3))]
+	[OxideHook.Parameter("radius", typeof(float))]
+	[OxideHook.Parameter("amount", typeof(int))]
+	[OxideHook.Info("Called before water is poured from a liquid vessel or shot from a water gun")]
+	[OxideHook.Patch(typeof(WaterBall), "DoSplash", typeof(Vector3), typeof(float), typeof(ItemDefinition), typeof(int))]
+	public class WaterBall_DoSplash
+	{
+		public static bool Prefix(Vector3 position, float radius, ItemDefinition liquidDef, int amount, ref bool __result)
+		{
+			var obj = Interface.CallHook("CanWaterBallSplash", liquidDef, position, radius, amount);
+
+			if (obj is bool)
+			{
+				__result = (bool)obj;
+				return __result;
+			}
+
+			return true;
+		}
+	}
+}

--- a/Carbon.Core/Carbon/Hooks/Oxide/Entity/OnSprinklerSplash.cs
+++ b/Carbon.Core/Carbon/Hooks/Oxide/Entity/OnSprinklerSplash.cs
@@ -1,0 +1,22 @@
+﻿///
+/// Copyright (c) 2022 Carbon Community 
+/// All rights reserved
+/// 
+
+using Carbon.Core;
+
+namespace Carbon.Extended
+{
+	[OxideHook("OnSprinklerSplashed"), OxideHook.Category(Hook.Category.Enum.Entity)]
+	[OxideHook.Parameter("this", typeof(Sprinkler))]
+	[OxideHook.Info("Called after any sprinkler has splashed water.")]
+	[OxideHook.Info("No return behavior.")]
+	[OxideHook.Patch(typeof(Sprinkler), "DoSplash")]
+	public class Sprinkler_DoSplash
+	{
+		public static void Postfix(ref Sprinkler __instance)
+		{
+			HookExecutor.CallStaticHook("OnSprinklerSplashed", __instance);
+		}
+	}
+}

--- a/Carbon.Core/Carbon/Hooks/Oxide/Resources/OnDispenserBonus.cs
+++ b/Carbon.Core/Carbon/Hooks/Oxide/Resources/OnDispenserBonus.cs
@@ -1,0 +1,93 @@
+﻿///
+/// Copyright (c) 2022 Carbon Community 
+/// All rights reserved
+/// 
+
+using Carbon.Core;
+using Oxide.Core;
+using ProtoBuf;
+using UnityEngine;
+using static Construction;
+
+namespace Carbon.Extended
+{
+	[OxideHook("OnDispenserBonus", typeof(Item)), OxideHook.Category(Hook.Category.Enum.Resources)]
+	[OxideHook.Parameter("this", typeof(ResourceDispenser))]
+	[OxideHook.Parameter("player", typeof(BasePlayer))]
+	[OxideHook.Parameter("item", typeof(Item))]
+	[OxideHook.Info("Called before the player is given a bonus item for gathering.")]
+	[OxideHook.Info("Returning an Item replaces the existing Item")]
+	[OxideHook.Info("Returning a false value overrides default behavior")]
+	[OxideHook.Patch(typeof(ResourceDispenser), "AssignFinishBonus")]
+	public class ResourceDispenser_AssignFinishBonus
+	{
+		public static bool Prefix(BasePlayer player, float fraction, ref ResourceDispenser __instance)
+		{
+			__instance.SendMessage("FinishBonusAssigned", SendMessageOptions.DontRequireReceiver);
+			if ((double)fraction <= 0.0 || __instance.finishBonus == null)
+				return false;
+			foreach (ItemAmount finishBonu in __instance.finishBonus)
+			{
+				int amountToGive = Mathf.CeilToInt((float)(int)finishBonu.amount * Mathf.Clamp01(fraction));
+				int gatherBonus = __instance.CalculateGatherBonus((BaseEntity)player, finishBonu, (float)amountToGive);
+				Item obj1 = ItemManager.Create(finishBonu.itemDef, amountToGive + gatherBonus);
+				if (obj1 != null)
+				{
+					object obj2 = HookExecutor.CallStaticHook("OnDispenserBonus", (object)__instance, (object)player, (object)obj1);
+					if (obj2 is bool)
+						if (!(bool)obj2)
+							continue;
+					if (obj2 is Item)
+						obj1 = (Item)obj2;
+					player.GiveItem(obj1, BaseEntity.GiveItemReason.ResourceHarvested);
+				}
+			}
+			return false;
+		}
+	}
+
+	[OxideHook("OnDispenserGather"), OxideHook.Category(Hook.Category.Enum.Resources)]
+	[OxideHook.Parameter("this", typeof(ResourceDispenser))]
+	[OxideHook.Parameter("entity", typeof(BaseEntity))]
+	[OxideHook.Parameter("item", typeof(Item))]
+	[OxideHook.Info("Called before the player is given items from a resource.")]
+	[OxideHook.Info("Returning a non-null value overrides default behavior")]
+	[OxideHook.Patch(typeof(ResourceDispenser), "GiveResourceFromItem")]
+	public class ResourceDispenser_GiveResourceFromItem
+	{
+		public static bool Prefix(BaseEntity entity, ItemAmount itemAmt, float gatherDamage, float destroyFraction, AttackEntity attackWeapon, ref ResourceDispenser __instance)
+		{
+			if ((double)itemAmt.amount == 0.0)
+				return false;
+			float num1 = Mathf.Min(gatherDamage, __instance.baseEntity.Health()) / __instance.baseEntity.MaxHealth();
+			float num2 = itemAmt.startAmount / __instance.startingItemCounts;
+			float num3 = Mathf.Round(Mathf.Clamp(itemAmt.startAmount * num1 / num2, 0.0f, itemAmt.amount));
+			float f = (float)((double)num3 * (double)destroyFraction * 2.0);
+			if ((double)itemAmt.amount <= (double)num3 + (double)f)
+			{
+				float num4 = (num3 + f) / itemAmt.amount;
+				num3 /= num4;
+				f /= num4;
+			}
+			itemAmt.amount -= Mathf.Floor(num3);
+			itemAmt.amount -= Mathf.Floor(f);
+			if ((double)num3 < 1.0)
+			{
+				num3 = (double)UnityEngine.Random.Range(0.0f, 1f) <= (double)num3 ? 1f : 0.0f;
+				itemAmt.amount = 0.0f;
+			}
+			if ((double)itemAmt.amount < 0.0)
+				itemAmt.amount = 0.0f;
+			if ((double)num3 < 1.0)
+				return false;
+			int gatherBonus = __instance.CalculateGatherBonus(entity, itemAmt, num3);
+			int iAmount = Mathf.FloorToInt(num3) + gatherBonus;
+			Item byItemId = ItemManager.CreateByItemID(itemAmt.itemid, iAmount);
+			if (HookExecutor.CallStaticHook("OnDispenserGather", (object)__instance, (object)entity, (object)byItemId) != null || byItemId == null)
+				return false;
+			__instance.OverrideOwnership(byItemId, attackWeapon);
+			entity.GiveItem(byItemId, BaseEntity.GiveItemReason.ResourceHarvested);
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
New Carbon hook

- `void OnGrowableUpdate(GrowableEntity ent)` - Called before growable entity will be updated.

Oxide hook

- `bool CanWaterBallSplash(ItemDefinition liquidDef, Vector3 position, float radius, int amount)` - Called before water is poured from a liquid vessel or shot from a water gun

- `void OnSprinklerSplashed(Sprinkler sprinkler)` - Called after any sprinkler has splashed water.

- `object OnDispenserBonus(ResourceDispenser dispenser, BasePlayer player, Item item)` - Called before the player is given a bonus item for gathering. Returning an Item replaces the existing Item. Returning a false value overrides default behavior.

- `object OnDispenserGather(ResourceDispenser dispenser, BaseEntity entity, Item item)` - Called before the player is given items from a resource.

All hooks were tested on the local host.