### PR TITLE
refactor: RustEditModule::ForceModded -> False

### DIFF
--- a/Carbon.Core/Carbon.Modules/src/RustEditModule/RustEditModule.cs
+++ b/Carbon.Core/Carbon.Modules/src/RustEditModule/RustEditModule.cs
@@ -43,7 +43,7 @@ public partial class RustEditModule : CarbonModule<RustEditConfig, EmptyModuleDa
 	internal static RustEditModule Singleton { get; set; }
 
 	public override string Name => "RustEdit.Ext";
-	public override bool ForceModded => true;
+	public override bool ForceModded => false;
 	public override Type Type => typeof(RustEditModule);
 
 	public override bool EnabledByDefault => false;


### PR DESCRIPTION
Facepunch doesn't disallow custom maps in the community section, and forcing this is one of the reasons I'm currently not using carbon. Would love to see this merged 👍 