### PR TITLE
SCRIPT variable inside init files fix

### DIFF
--- a/Tools/Helpers/carbon.sh
+++ b/Tools/Helpers/carbon.sh
@@ -5,6 +5,6 @@
 ### All rights reserved
 ###
 
-SCRIPT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-source "${SCRIPT}/carbon/tools/environment.sh"
-"${SCRIPT}/RustDedicated" "$@"
+CARBON_INIT_SCRIPT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${CARBON_INIT_SCRIPT}/carbon/tools/environment.sh"
+"${CARBON_INIT_SCRIPT}/RustDedicated" "$@"

--- a/Tools/Helpers/environment.sh
+++ b/Tools/Helpers/environment.sh
@@ -6,8 +6,8 @@
 ###
 
 # Get the directory of the executable
-SCRIPT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-BASEDIR=$(realpath "${SCRIPT}/../../")
+CARBON_ENV_SCRIPT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BASEDIR=$(realpath "${CARBON_ENV_SCRIPT}/../../")
 
 # Docker workaround
 export TERM=xterm


### PR DESCRIPTION
The same var exists in different shell scripts and overwrites its value.
[${SCRIPT}/RustDedicated](https://github.com/CarbonCommunity/Carbon/blob/develop/Tools/Helpers/carbon.sh#L10) tries to find server executable inside wrong directory once it happens.