### PR TITLE
Bump submodule SteamRE/DepotDownloader

### DIFF
--- a/Tools/Build/linux/update.sh
+++ b/Tools/Build/linux/update.sh
@@ -42,7 +42,7 @@ done
 
 for OS in windows linux; do
 	# Download rust binary libs
-	"${ROOT}/Tools/DepotDownloader/DepotDownloader/bin/Release/net6.0/DepotDownloader" \
+	"${ROOT}/Tools/DepotDownloader/DepotDownloader/bin/Release/net8.0/DepotDownloader" \
 		-os ${OS} -validate -app 258550 -branch ${TARGET} -filelist \
 		"${ROOT}/Tools/Helpers/258550_refs.txt" -dir "${ROOT}/Rust/${OS}"
 

--- a/Tools/Build/win/update.bat
+++ b/Tools/Build/win/update.bat
@@ -41,7 +41,7 @@ FOR %%O IN (windows linux) DO (
 	echo Downloading %%O Rust files..
 
 	rem Download rust binary libs
-	"%UPDATE_ROOT%\Tools\DepotDownloader\DepotDownloader\bin\Release\net6.0\DepotDownloader.exe" ^
+	"%UPDATE_ROOT%\Tools\DepotDownloader\DepotDownloader\bin\Release\net8.0\DepotDownloader.exe" ^
 		-os %%O -validate -app 258550 -branch %UPDATE_TARGET% -filelist ^
 		"%UPDATE_ROOT%\Tools\Helpers\258550_refs.txt" -dir "%UPDATE_ROOT%\Rust\%%O"
 


### PR DESCRIPTION
setup.bat script results in latest DepotDownloader version anyway, this fixes the path error because the build outputs to net8.0 that others are having

https://discord.com/channels/1013291619765723196/1013291621065949241/1240972247938891867