### PR TITLE
fix: error when debugOutputPath is null.

### DIFF
--- a/Carbon.Core/Carbon.Tools/Carbon.Generator.Shared/Generator.cs
+++ b/Carbon.Core/Carbon.Tools/Carbon.Generator.Shared/Generator.cs
@@ -281,7 +281,8 @@ partial class {@class.Identifier.ValueText}
 #if DEBUG
 		if (isPartial)
 		{
-			path = Path.Combine(debugOutputPath, $"{Path.GetFileNameWithoutExtension(fileName)}.Internal.cs");
+			string fileNameWithNewExt = $"{Path.GetFileNameWithoutExtension(fileName)}.Internal.cs";
+			path = debugOutputPath != null ? Path.Combine(debugOutputPath, fileNameWithNewExt) : fileNameWithNewExt;
 			output = CSharpSyntaxTree.ParseText(source, options, path, Encoding.UTF8).GetCompilationUnitRoot().NormalizeWhitespace();
 			File.WriteAllText(path, output.ToFullString());
 		}


### PR DESCRIPTION
This Pull Request fixes an issue where `Path.Combine` was receiving a `null` argument. The parameter `debugOutputPath` could be `null`, and due to missing null handling, it caused the following exception:

```
[2025.03.24 18:16:34] [ERRO] Threading compilation failed for 'C:\steamcmd\steamapps\common\rust_dedicated\carbon\plugins\cszip_dev\MyPlugin' [Thread Pool Worker|53] (Value cannot be null.
Parameter name: path1)
   at string System.IO.Path.Combine(string path1, string path2)
   at void Carbon.Generator.InternalCallHook.GeneratePartial(CompilationUnitSyntax input, out CompilationUnitSyntax output, CSharpParseOptions options, string fileName, List<ClassDeclarationSyntax> classes, string debugOutputPath) in /__w/Carbon/Carbon/Carbon.Core/Carbon.Tools/Carbon.Generator.Shared/Generator.cs:line 284
   at void Carbon.Jobs.ScriptCompilationThread.ThreadFunction() in /__w/Carbon/Carbon/Carbon.Core/Carbon/src/Threads/ScriptCompilationThread.cs:line 433
```