### PR TITLE
Change command matching to use StartsWith instead of Equals

### DIFF
--- a/src/Carbon.Components/Carbon.SDK/src/Commands/Classes/Command.cs
+++ b/src/Carbon.Components/Carbon.SDK/src/Commands/Classes/Command.cs
@@ -14,7 +14,7 @@ public class Command : IDisposable
 	{
 		foreach (var prefix in Prefixes)
 		{
-			if (!prefix.Value.Equals(command, StringComparison.OrdinalIgnoreCase))
+			if (!prefix.Value.StartsWith(command, StringComparison.OrdinalIgnoreCase))
 			{
 				continue;
 			}


### PR DESCRIPTION
Change command matching to use StartsWith instead of Equals, like Oxide does. Also requires this PR https://github.com/CarbonCommunity/Carbon.Hooks.Base/pull/4