### PR TITLE
Log a warning when timer left in zombie state

### DIFF
--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/Timer.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/Timer.cs
@@ -64,6 +64,10 @@ public class Timers : Library
 		{
 			Persistence.Invoke(activity, time);
 		}
+		else
+		{
+			Logger.Warn($"Plugin '{Plugin.ToPrettyString()}' created a {time}s timer before OnServerInitialized(); it will probably never fire");
+		}
 
 		return timer;
 	}


### PR DESCRIPTION
If a plugin calls `timer.In()` or `timer.Once()` before `OnServerInitialized()`, Carbon will never schedule it, leaving it in a zombie state forever.

This change at least adds a warning so that plugin developers and sever owners have visibility into this zombie timer state.

Examples of this happening in the wild include Discord Chat by MJSU (breaks server booting messages) and Zone Manager by k1lly0u (probably harmless since it seems to be the result of `OnPlayerSleep()` firing for non-players).