### PR TITLE
Respect LUI Scrollbar disabled field

### DIFF
--- a/src/Carbon.Components/Carbon.Common/src/Carbon/Components/LUIBuilder.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/Components/LUIBuilder.cs
@@ -1166,7 +1166,7 @@ public struct LuiBuilderInstance : IDisposable
 			                    this.WriteComma();
 			                    this.WriteField("scrollSensitivity", scroll.scrollSensitivity);
 		                    }
-		                    if (scroll.horizontal)
+		                    if (scroll.horizontal  && !scroll.horizontalScrollbar.disabled)
 		                    {
 			                    this.WriteComma();
 			                    this.WriteStartObject("horizontalScrollbar");
@@ -1174,7 +1174,7 @@ public struct LuiBuilderInstance : IDisposable
 			                    this.WriteEndObject();
 
 		                    }
-		                    if (scroll.vertical)
+		                    if (scroll.vertical && !scroll.verticalScrollbar.disabled)
 		                    {
 			                    this.WriteComma();
 			                    this.WriteStartObject("verticalScrollbar");


### PR DESCRIPTION
Fixes an issue where `LuiScrollbar.disabled = true` still results in a visible scrollbar being created.

Previously, disabled scrollbars were serialized as:

```json
"verticalScrollbar": {
  "enabled": false
}
```

Rust's UI implementation creates a scrollbar whenever the `verticalScrollbar` or `horizontalScrollbar` object is present, regardless of its enabled state.

This change stops disabled scrollbars from being sent entirely, matching the expected behavior of the `disabled` option and makes sure no scrollbar is displayed when disabled.