### PR TITLE
add webcalls for cui add/destroy requests.

### DIFF
--- a/src/Carbon.Components/Carbon.Common/src/Carbon/WebControlPanel/WebControlPanel.Accounts.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/WebControlPanel/WebControlPanel.Accounts.cs
@@ -69,6 +69,7 @@ public static partial class WebControlPanel
 				PermissionTypes.PluginsEdit => account.Permissions.plugins_edit,
 				PermissionTypes.MapView => account.Permissions.map_view,
 				PermissionTypes.MapEntities => account.Permissions.map_entities,
+				PermissionTypes.DrawUi => account.Permissions.draw_ui,
 				_ => false
 			};
 		}
@@ -94,6 +95,7 @@ public static partial class WebControlPanel
 		public bool plugins_edit = enabled;
 		public bool map_view = enabled;
 		public bool map_entities = enabled;
+		public bool draw_ui = enabled;
 
 		public void Serialize(BridgeWrite write)
 		{
@@ -115,6 +117,7 @@ public static partial class WebControlPanel
 			write.WriteObject(plugins_edit);
 			write.WriteObject(map_view);
 			write.WriteObject(map_entities);
+			write.WriteObject(draw_ui);
 		}
 	}
 
@@ -138,6 +141,7 @@ public static partial class WebControlPanel
 		PluginsView,
 		PluginsEdit,
 		MapView,
-		MapEntities
+		MapEntities,
+		DrawUi
 	}
 }

--- a/src/Carbon.Components/Carbon.Common/src/Carbon/WebControlPanel/WebControlPanel.Rpc.Cui.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Carbon/WebControlPanel/WebControlPanel.Rpc.Cui.cs
@@ -1,0 +1,37 @@
+﻿using Facepunch;
+using Oxide.Game.Rust.Cui;
+
+namespace Carbon;
+
+public static partial class WebControlPanel
+{
+	[WebCall]
+	[WebCall.Condition.Permission(PermissionTypes.DrawUi)]
+	private static void RPC_AddUi(BridgeRead read)
+	{
+		var player = BasePlayer.FindAwakeOrSleepingByID(read.UInt64());
+		if (!player.IsValid())
+		{
+			return;
+		}
+
+		var json = read.String();
+		if (!string.IsNullOrWhiteSpace(json))
+		{
+			CuiHelper.AddUi(player, json);
+		}
+	}
+
+	[WebCall]
+	[WebCall.Condition.Permission(PermissionTypes.DrawUi)]
+	private static void RPC_DestroyUi(BridgeRead read)
+	{
+		var player = BasePlayer.FindAwakeOrSleepingByID(read.UInt64());
+		if (!player.IsValid())
+		{
+			return;
+		}
+
+		CuiHelper.DestroyUi(player, read.String());
+	}
+}


### PR DESCRIPTION
Add RPC_AddUi and RPC_DestroyUI calls for bridge as well as permission draw_ui to gate it. Used for layout designer live previewing (future carbon docs tool).