### PR TITLE
Fix: Refresh display name on connection

### DIFF
--- a/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/Permissions.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Oxide/Libraries/Permissions.cs
@@ -509,6 +509,7 @@ public class Permission : Library
 		}
 
 		rustPlayer.Object = player;
+		rustPlayer.Name = player.displayName.Sanitize();
 	}
 	public virtual void UpdateNickname(string id, string nickname)
 	{


### PR DESCRIPTION
Resolves the issue with many plugins not using the updated display name of players until server restarts. 