### PR TITLE
fix: ScriptLoader teardown racing its compile thread

### DIFF
--- a/src/Carbon.Components/Carbon.Common/src/Base/BaseThreadedJob.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Base/BaseThreadedJob.cs
@@ -9,7 +9,7 @@ public class BaseThreadedJob : IDisposable
 	private CancellationTokenSource cancellationToken;
 	private volatile bool _isAborted;
 
-	internal object _abortHandle = new();
+	internal readonly object _abortHandle = new();
 
 	public CancellationToken CancellationToken => cancellationToken?.Token ?? CancellationToken.None;
 	public bool IsAborted => _isAborted;
@@ -83,8 +83,14 @@ public class BaseThreadedJob : IDisposable
 	}
 	private void Run()
 	{
-		ThreadFunction();
-		IsDone = true;
+		try
+		{
+			ThreadFunction();
+		}
+		finally
+		{
+			IsDone = true;
+		}
 	}
 
 	public virtual void Dispose() { }

--- a/src/Carbon.Components/Carbon.Common/src/Base/BaseThreadedJob.cs
+++ b/src/Carbon.Components/Carbon.Common/src/Base/BaseThreadedJob.cs
@@ -7,6 +7,12 @@ public class BaseThreadedJob : IDisposable
 	internal Task _task = null;
 
 	private CancellationTokenSource cancellationToken;
+	private volatile bool _isAborted;
+
+	internal object _abortHandle = new();
+
+	public CancellationToken CancellationToken => cancellationToken?.Token ?? CancellationToken.None;
+	public bool IsAborted => _isAborted;
 
 	public bool IsDone
 	{
@@ -30,6 +36,12 @@ public class BaseThreadedJob : IDisposable
 
 	public virtual void Start()
 	{
+		if (IsAborted)
+		{
+			IsDone = true;
+			return;
+		}
+
 		if (Community.IsServerInitialized)
 		{
 			cancellationToken = new CancellationTokenSource();
@@ -42,6 +54,11 @@ public class BaseThreadedJob : IDisposable
 	}
 	public virtual void Abort()
 	{
+		lock (_abortHandle)
+		{
+			_isAborted = true;
+		}
+
 		cancellationToken?.Cancel();
 	}
 

--- a/src/Carbon/src/Loaders/ScriptLoader.cs
+++ b/src/Carbon/src/Loaders/ScriptLoader.cs
@@ -40,6 +40,8 @@ public class ScriptLoader : IScriptLoader
 	public IBaseProcessor.IParser Parser { get; set; }
 	public ScriptCompilationThread AsyncLoader { get; set; } = new();
 
+	private IEnumerator _compileRoutine;
+
 	public void Load()
 	{
 		if (InitialSource == null || string.IsNullOrEmpty(InitialSource.FilePath))
@@ -53,7 +55,8 @@ public class ScriptLoader : IScriptLoader
 			var directory = Path.GetDirectoryName(InitialSource.FilePath);
 			IsExtension = directory.EndsWith("extensions");
 
-			Community.Runtime.ScriptProcessor.StartCoroutine(Compile());
+			_compileRoutine = Compile();
+			Community.Runtime.ScriptProcessor.StartCoroutine(_compileRoutine);
 		}
 		catch (Exception exception)
 		{
@@ -592,7 +595,11 @@ public class ScriptLoader : IScriptLoader
 
 	public void Dispose()
 	{
-		Community.Runtime.ScriptProcessor.StopCoroutine(Compile());
+		if (_compileRoutine != null)
+		{
+			Community.Runtime.ScriptProcessor.StopCoroutine(_compileRoutine);
+			_compileRoutine = null;
+		}
 
 		HasFinished = true;
 

--- a/src/Carbon/src/Loaders/ScriptLoader.cs
+++ b/src/Carbon/src/Loaders/ScriptLoader.cs
@@ -362,6 +362,8 @@ public class ScriptLoader : IScriptLoader
 			yield break;
 		}
 
+		Pool.FreeUnmanaged(ref missingRequires);
+
 		yield return null;
 
 		var requiresResult = requires.ToArray();
@@ -377,7 +379,6 @@ public class ScriptLoader : IScriptLoader
 		{
 			HasFinished = true;
 			Pool.FreeUnmanaged(ref requires);
-			Pool.FreeUnmanaged(ref missingRequires);
 			yield break;
 		}
 
@@ -462,7 +463,6 @@ public class ScriptLoader : IScriptLoader
 			AsyncLoader.Exceptions = AsyncLoader.Warnings = null;
 			HasFinished = true;
 			Pool.FreeUnmanaged(ref requires);
-			Pool.FreeUnmanaged(ref missingRequires);
 
 			if (Community.AllProcessorsFinalized)
 			{
@@ -474,7 +474,6 @@ public class ScriptLoader : IScriptLoader
 		if (AsyncLoader == null)
 		{
 			Pool.FreeUnmanaged(ref requires);
-			Pool.FreeUnmanaged(ref missingRequires);
 			yield break;
 		}
 
@@ -589,7 +588,6 @@ public class ScriptLoader : IScriptLoader
 		}
 
 		Pool.FreeUnmanaged(ref requires);
-		Pool.FreeUnmanaged(ref missingRequires);
 		yield return null;
 	}
 

--- a/src/Carbon/src/Loaders/ScriptLoader.cs
+++ b/src/Carbon/src/Loaders/ScriptLoader.cs
@@ -303,7 +303,7 @@ public class ScriptLoader : IScriptLoader
 
 		if (AsyncLoader != null)
 		{
-			AsyncLoader.Sources = Sources;
+			AsyncLoader.Sources = new List<ISource>(Sources);
 			AsyncLoader.References = resultReferences?.ToArray();
 			AsyncLoader.Requires = resultRequires?.ToArray();
 			AsyncLoader.IsExtension = IsExtension;

--- a/src/Carbon/src/Loaders/ScriptLoader.cs
+++ b/src/Carbon/src/Loaders/ScriptLoader.cs
@@ -607,15 +607,6 @@ public class ScriptLoader : IScriptLoader
 			}
 		}
 
-		if (Sources != null)
-		{
-			foreach (var source in Sources)
-			{
-				source.Dispose();
-			}
-		}
-
-		Sources?.Clear();
 		Scripts?.Clear();
 		Sources = null;
 		Scripts = null;

--- a/src/Carbon/src/Threads/ScriptCompilationThread.cs
+++ b/src/Carbon/src/Threads/ScriptCompilationThread.cs
@@ -68,27 +68,11 @@ public class ScriptCompilationThread : BaseThreadedJob
 	{
 		name = name.Replace(" ", string.Empty);
 
-		foreach (var plugin in _compilationCache)
-		{
-			if (plugin.Key == name)
-			{
-				return plugin.Value;
-			}
-		}
-
-		return null;
+		return _compilationCache.TryGetValue(name, out var plugin) ? plugin : null;
 	}
 	private static byte[] _getExtensionPlugin(string name)
 	{
-		foreach (var extension in _extensionCompilationCache)
-		{
-			if (extension.Key == name)
-			{
-				return extension.Value;
-			}
-		}
-
-		return null;
+		return _extensionCompilationCache.TryGetValue(name, out var extension) ? extension : null;
 	}
 	private static void _overridePlugin(string name, byte[] pluginAssembly)
 	{

--- a/src/Carbon/src/Threads/ScriptCompilationThread.cs
+++ b/src/Carbon/src/Threads/ScriptCompilationThread.cs
@@ -694,7 +694,14 @@ public class ScriptCompilationThread : BaseThreadedJob
 									: InitialSource.ContextFileName);
 
 								var isProfiled = MonoProfiler.TryStartProfileFor(MonoProfilerConfig.ProfileTypes.Plugin, Assembly, name, true);
-								Assemblies.Plugins.Update(name, Assembly, string.IsNullOrEmpty(InitialSource.ContextFilePath) ? InitialSource.FilePath : InitialSource.ContextFilePath, isProfiled);
+
+								lock (_abortHandle)
+								{
+									if (!IsAborted)
+									{
+										Assemblies.Plugins.Update(name, Assembly, string.IsNullOrEmpty(InitialSource.ContextFilePath) ? InitialSource.FilePath : InitialSource.ContextFilePath, isProfiled);
+									}
+								}
 							}
 							catch (Exception ex)
 							{

--- a/src/Carbon/src/Threads/ScriptCompilationThread.cs
+++ b/src/Carbon/src/Threads/ScriptCompilationThread.cs
@@ -366,6 +366,12 @@ public class ScriptCompilationThread : BaseThreadedJob
 	}
 	public override void Start()
 	{
+		if (IsAborted)
+		{
+			IsDone = true;
+			return;
+		}
+
 		IsCompileTestMode = Community.Runtime?.Config?.Compiler?.CompileTestMode ?? false;
 
 		PrewarmInternalHookGenerator();
@@ -438,7 +444,7 @@ public class ScriptCompilationThread : BaseThreadedJob
 	}
 	public override void ThreadFunction()
 	{
-		if (Sources.TrueForAll(x => string.IsNullOrEmpty(x.Content)))
+		if (IsAborted || Sources.TrueForAll(x => string.IsNullOrEmpty(x.Content)))
 		{
 			Dispose();
 			return;
@@ -583,7 +589,7 @@ public class ScriptCompilationThread : BaseThreadedJob
 
 			_stopwatch.Restart();
 
-			if (InitialSource == null)
+			if (InitialSource == null || IsAborted)
 			{
 				Dispose();
 				return;
@@ -593,7 +599,17 @@ public class ScriptCompilationThread : BaseThreadedJob
 
 			using (var dllStream = new MemoryStream())
 			{
-				var emit = compilation.Emit(dllStream, options: _emitOptions);
+				EmitResult emit;
+
+				try
+				{
+					emit = compilation.Emit(dllStream, options: _emitOptions, cancellationToken: CancellationToken);
+				}
+				catch (OperationCanceledException)
+				{
+					Dispose();
+					return;
+				}
 
 				var errors = Pool.Get<List<string>>();
 				var warnings = Pool.Get<List<string>>();
@@ -640,15 +656,25 @@ public class ScriptCompilationThread : BaseThreadedJob
 					IsCompileSuccess = true;
 
 					var assembly = dllStream.ToArray();
-					if (assembly != null)
+					var published = false;
+
+					lock (_abortHandle)
 					{
-						if (IsExtension)
+						if (assembly != null && !IsAborted)
 						{
-							_overrideExtensionPlugin(InitialSource.ContextFilePath, assembly);
+							published = true;
+
+							if (IsExtension)
+							{
+								_overrideExtensionPlugin(InitialSource.ContextFilePath, assembly);
+							}
+
+							_overridePlugin(Path.GetFileNameWithoutExtension(InitialSource.ContextFilePath), assembly);
 						}
+					}
 
-						_overridePlugin(Path.GetFileNameWithoutExtension(InitialSource.ContextFilePath), assembly);
-
+					if (published)
+					{
 						if (IsCompileTestMode)
 						{
 							// Compile-test mode: the emitted IL must never reach the AppDomain, so no Assembly.Load,

--- a/src/Carbon/src/Threads/ScriptCompilationThread.cs
+++ b/src/Carbon/src/Threads/ScriptCompilationThread.cs
@@ -444,13 +444,16 @@ public class ScriptCompilationThread : BaseThreadedJob
 			return;
 		}
 
+		var trees = (List<SyntaxTree>)null;
+		var conditionals = (List<string>)null;
+
 		try
 		{
 			Exceptions.Clear();
 			Warnings.Clear();
 
-			var trees = Pool.Get<List<SyntaxTree>>();
-			var conditionals = Pool.Get<List<string>>();
+			trees = Pool.Get<List<SyntaxTree>>();
+			conditionals = Pool.Get<List<string>>();
 
 			_stopwatch = Pool.Get<Stopwatch>();
 
@@ -676,14 +679,7 @@ public class ScriptCompilationThread : BaseThreadedJob
 				}
 			}
 
-			references.Clear();
-			references = null;
-			Pool.FreeUnmanaged(ref conditionals);
-			Pool.FreeUnmanaged(ref trees);
-
 			CompileTime = _stopwatch.Elapsed;
-			_stopwatch.Reset();
-			Pool.FreeUnsafe(ref _stopwatch);
 
 			// Belt-and-braces: never reflect over the compiled types in compile-test mode. Walking them would
 			// resolve the plugin's type graph (and any type initializers hanging off it) inside our AppDomain.
@@ -739,6 +735,27 @@ public class ScriptCompilationThread : BaseThreadedJob
 		{
 			Logger.Error($"Threading compilation failed for '{InitialSource?.ContextFilePath}'", ex);
 			Analytics.plugin_native_compile_fail(InitialSource, ex);
+		}
+		finally
+		{
+			references?.Clear();
+			references = null;
+
+			if (conditionals != null)
+			{
+				Pool.FreeUnmanaged(ref conditionals);
+			}
+
+			if (trees != null)
+			{
+				Pool.FreeUnmanaged(ref trees);
+			}
+
+			if (_stopwatch != null)
+			{
+				_stopwatch.Reset();
+				Pool.FreeUnsafe(ref _stopwatch);
+			}
 		}
 	}
 	public override void Dispose()


### PR DESCRIPTION
## Summary
Assigns a copy of the `Sources` list to `AsyncLoader.Sources` instead of passing the original reference, preventing shared mutation between the `ScriptLoader` and `AsyncLoader`.

This bug is user facing and reported on August 15th 2026 by [Discord](https://discord.com/channels/1013291619765723196/1013291621065949241/1538255763531898901)
 
## Problem
`AsyncLoader.Sources` was being set to the same `List<ISource>` instance as `ScriptLoader.Sources`. Any subsequent modifications to the list in `ScriptLoader` would also affect `AsyncLoader`, leading to potential race conditions or unexpected behavior during async compilation.
 
## Fix
Changed `AsyncLoader.Sources = Sources` to `AsyncLoader.Sources = new List<ISource>(Sources)`